### PR TITLE
2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-api",
-  "version": "2.5.0-beta.0",
+  "version": "2.5.0-beta.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-api",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-api",
-  "version": "2.5.0-beta.1",
+  "version": "2.5.0-beta.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-api",
-  "version": "2.4.0",
+  "version": "2.5.0-beta.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/base-data.ts
+++ b/src/base-data.ts
@@ -1,6 +1,8 @@
+import {ShortcutApiFieldType} from '@sx/utils/field-type'
+
 /**
  * Represents the data returned from the API.
  */
 export default interface BaseData {
-    [key: string]: unknown
+    [key: string]: ShortcutApiFieldType
 }

--- a/src/base-interface.ts
+++ b/src/base-interface.ts
@@ -1,8 +1,10 @@
+import {ShortcutFieldType} from '@sx/utils/field-type'
 import UUID from '@sx/utils/uuid'
 
 /**
  * Base interface for Shortcut resources, representing the data returned from the API following JavaScript naming conventions.
  */
 export default interface BaseInterface {
+    [key: string]: ShortcutFieldType
     id?: UUID | number | null
 }

--- a/src/base-resource.ts
+++ b/src/base-resource.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 import BaseInterface from '@sx/base-interface'
 import camelToSnake from '@sx/utils/camel-to-snake'
+import {ShortcutApiFieldType, ShortcutFieldType} from '@sx/utils/field-type'
 import {handleResponseFailure} from '@sx/utils/handle-response-failure'
 import {getHeaders} from '@sx/utils/headers'
 import snakeToCamel from '@sx/utils/snake-to-camel'
@@ -16,7 +17,7 @@ export type ResourceOperation = 'update' | 'create' | 'delete' | 'comment'
  * @group Story
  */
 export default abstract class ShortcutResource<Interface = BaseInterface> {
-  [key: string]: unknown
+  [key: string]: ShortcutFieldType
 
   /**
    * @internal
@@ -95,7 +96,7 @@ export default abstract class ShortcutResource<Interface = BaseInterface> {
         if (!response) {
           return
         }
-        const data: Record<string, unknown> = response!.data
+        const data: Record<string, ShortcutApiFieldType> = response!.data
         Object.keys(data).forEach(key => {
           this[snakeToCamel(key)] = data[key]
           this.changedFields = []

--- a/src/base-service.ts
+++ b/src/base-service.ts
@@ -4,6 +4,7 @@ import BaseData from '@sx/base-data'
 import BaseInterface from '@sx/base-interface'
 import ShortcutResource from '@sx/base-resource'
 import {convertApiFields} from '@sx/utils/convert-fields'
+import {ShortcutApiFieldType} from '@sx/utils/field-type'
 import UUID from '@sx/utils/uuid'
 
 
@@ -37,8 +38,8 @@ export default class BaseService<Resource extends ShortcutResource, Interface ex
     if (response.status >= 400) {
       throw new Error('HTTP error ' + response.status)
     }
-    const instanceData: Interface = convertApiFields(response.data)
-    const instance = this.factory(instanceData)
+    const instanceData: Interface = convertApiFields<BaseData, Interface>(response.data)
+    const instance: Resource = this.factory(instanceData)
     this.instances[id] = instance
     return instance
   }
@@ -55,7 +56,7 @@ export default class BaseService<Resource extends ShortcutResource, Interface ex
     if (response.status >= 400) {
       throw new Error('HTTP error ' + response.status)
     }
-    const instancesData: Record<string, unknown>[] = response.data ?? []
+    const instancesData: Record<string, ShortcutApiFieldType>[] = response.data ?? []
 
     const resources: Resource[] = instancesData.map((instance) => this.factory(convertApiFields(instance)))
     this.instances = resources.reduce((acc: Record<string, Resource>, resource: Resource) => {

--- a/src/base-service.ts
+++ b/src/base-service.ts
@@ -8,10 +8,10 @@ import {ShortcutApiFieldType} from '@sx/utils/field-type'
 import UUID from '@sx/utils/uuid'
 
 
-export type ServiceOperation = 'get' | 'search' | 'list'
+type ServiceOperation = 'get' | 'search' | 'list'
 
 
-export default class BaseService<Resource extends ShortcutResource, Interface extends BaseInterface> {
+class BaseService<Resource extends ShortcutResource, Interface extends BaseInterface> {
   public baseUrl = ''
   public headers: Record<string, string>
   protected factory: (data: Interface) => Resource
@@ -71,8 +71,15 @@ export default class BaseService<Resource extends ShortcutResource, Interface ex
   }
 }
 
-export class BaseSearchableService<Resource extends ShortcutResource, Interface extends BaseInterface> extends BaseService<Resource, Interface> {
+
+interface SearchResponse {
+  next?: string
+  results: ShortcutResource[]
+}
+
+class BaseSearchableService<Resource extends ShortcutResource, Interface extends BaseInterface> extends BaseService<Resource, Interface> {
   public availableOperations: ServiceOperation[] = ['search']
+
 
   /**
    * Search for resources using the [Shortcut Syntax](https://help.shortcut.com/hc/en-us/articles/360000046646-Searching-in-Shortcut-Using-Search-Operators)
@@ -90,7 +97,7 @@ export class BaseSearchableService<Resource extends ShortcutResource, Interface 
    * @param query - The search query to use
    * @param next - The next page token to use for pagination
    */
-  public async search(query: string, next?: string): Promise<{ next?: string, results: Resource[] }>{
+  public async search(query: string, next?: string): Promise<SearchResponse>{
     let url = new URL('https://api.app.shortcut.com/api/v3/search/stories')
     if (next) {
       url = new URL(`https://api.app.shortcut.com${next}`)
@@ -114,3 +121,6 @@ export class BaseSearchableService<Resource extends ShortcutResource, Interface 
 
   }
 }
+
+export default BaseService
+export {BaseSearchableService, BaseService, SearchResponse, ServiceOperation}

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,0 +1,82 @@
+import ShortcutResource from '@sx/base-resource'
+import {ShortcutFieldType} from '@sx/utils/field-type'
+import UUID from '@sx/utils/uuid'
+
+
+/**
+ * To make bulk updates to multiple instances of a resource, use the Bundle class. A bundle can be created with a list of instance ids and a
+ * factory function that creates a new instance of the resource with the given id. Alternatively, a bundle can be created with a list of instances.
+ * In order to make changes to the instances, the bundle object should be used as a proxy object. This will track all changes made to the object
+ * and mirror them on the instances. When the `update` method is called, all changes will be sent to the API to update the instances.
+ *
+ * @example
+ * const bundle = new Bundle<Story>({ids: [1, 2, 3]}, (data) => new Story(data))
+ * bundle.estimate = 3
+ * bundle.update() // Changes are propagated to the instances and sent to the API
+ */
+class Bundle<R extends ShortcutResource>{
+  [key: string]: ShortcutFieldType
+
+  id?: string | number | null | undefined
+
+  public changedFields: string[] = []
+  public instanceIds: UUID[] | number[] = []
+  public resources: ShortcutResource[]
+  public factory: (data: { id: UUID | number }) => R
+
+
+  /**
+   * Create a new Bundle object
+   * @param bundled - Either a list of instance ids or a list of instances
+   * @param factory - A function that creates a new instance of the resource with the given id, required if bundled is a list of ids
+   * @example
+   * const bundle = new Bundle<Story>([1, 2, 3], (data) => new Story(data))
+   * const otherBundle = new Bundle<Story>([new Story({id: 1}), new Story({id: 2})])
+   */
+  constructor(bundled: Array<UUID | number> | Array<R>, factory?: (data: { id: UUID | number }) => R){
+    // If the bundled parameter is an array of ids, not an array of R, create the resources
+    if(Array.isArray(bundled) && typeof bundled[0] === 'number' || typeof bundled[0] ===  'string'){
+      this.factory = factory!
+      this.instanceIds = <UUID[] | number[]>bundled
+      this.#createResources()
+    }
+    else{
+      this.resources = <R[]>bundled
+    }
+    return new Proxy(this, {
+      get(target, property: string | symbol, receiver) {
+        return Reflect.get(target, property, receiver)
+      },
+      set(target, property: string | symbol, value, receiver) {
+        // Check that property is defined on R
+        if (!Reflect.has(target.resources[0], property)) {
+          throw new Error(`Property ${String(property)} is not defined on ${target.resources[0].constructor.name}`)
+        }
+        // Track all changes made to the object
+        if (!target.changedFields.includes(String(property))) {
+          target.changedFields.push(String(property))
+        }
+        return Reflect.set(target, property, value, receiver)
+      }
+    })
+  }
+
+  #createResources(): void {
+    this.resources = this.instanceIds.map(id => this.factory({id}))
+  }
+
+  public async update(): Promise<void> {
+    for (const resource of this.resources) {
+      for (const field of this.changedFields) {
+        if (field.startsWith('_')) {
+          continue
+        }
+        resource[field] = this[field]
+      }
+      await resource.update()
+    }
+  }
+}
+
+
+export default Bundle

--- a/src/epics/contracts/epic-interface.ts
+++ b/src/epics/contracts/epic-interface.ts
@@ -1,7 +1,8 @@
+import BaseInterface from '@sx/base-interface'
 import UUID from '@sx/utils/uuid'
 
 
-export default interface EpicInterface {
+export default interface EpicInterface extends BaseInterface {
     appUrl: string
     archived: boolean
     associatedGroups: []

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 
+// Resources
 import ShortcutResource from '@sx/base-resource'
 import Client from '@sx/client'
 import Iteration from '@sx/iterations/iteration'
@@ -40,6 +41,9 @@ import CreateLinkedFileData from '@sx/linked-files/contracts/create-linked-file-
 import CustomFieldInterface from '@sx/custom-fields/contracts/custom-field-interface'
 import UploadedFileInterface from '@sx/uploaded-files/contracts/uploaded-file-interface'
 
+// Utils
+import Bundle from '@sx/bundle'
+
 export default Client
 export {Client, Iteration, Member, Story, Team, Workflow, Epic, Objective, Label, KeyResult, LinkedFile, CustomField, UploadedFile}
 export {
@@ -67,4 +71,4 @@ export {
     CustomFieldInterface,
     UploadedFileInterface
 }
-export {ShortcutResource}
+export {Bundle, ShortcutResource}

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import UploadedFileInterface from '@sx/uploaded-files/contracts/uploaded-file-in
 
 // Utils
 import Bundle from '@sx/bundle'
+import {SearchResponse} from '@sx/base-service'
 
 export default Client
 export {Client, Iteration, Member, Story, Team, Workflow, Epic, Objective, Label, KeyResult, LinkedFile, CustomField, UploadedFile}
@@ -71,4 +72,4 @@ export {
     CustomFieldInterface,
     UploadedFileInterface
 }
-export {Bundle, ShortcutResource}
+export {Bundle, ShortcutResource, SearchResponse}

--- a/src/linked-files/contracts/linked-file-interface.ts
+++ b/src/linked-files/contracts/linked-file-interface.ts
@@ -1,7 +1,8 @@
+import BaseInterface from '@sx/base-interface'
 import UUID from '@sx/utils/uuid'
 
 
-export default interface LinkedFileInterface {
+export default interface LinkedFileInterface extends BaseInterface {
     contentType: string
     createdAt: Date
     description: string

--- a/src/stories/history/contracts/history-api-data.ts
+++ b/src/stories/history/contracts/history-api-data.ts
@@ -9,7 +9,6 @@ export default interface HistoryApiData extends BaseData {
     external_id: string
     id: UUID
     member_id: UUID
-    primary_id: undefined
     references: []
     version: string
     webhook_id: string

--- a/src/stories/history/flat-history.ts
+++ b/src/stories/history/flat-history.ts
@@ -1,5 +1,6 @@
 import BaseInterface from '@sx/base-interface'
 import Member from '@sx/members/member'
+import {ShortcutFieldType} from '@sx/utils/field-type'
 import UUID from '@sx/utils/uuid'
 import WorkflowState from '@sx/workflow-states/workflow-state'
 
@@ -8,8 +9,8 @@ interface FlatHistory extends BaseInterface {
   member: Member
   changedAt: Date
   id: UUID
-  newValue: unknown | WorkflowState
-  oldValue: unknown| WorkflowState
+  newValue: ShortcutFieldType | WorkflowState
+  oldValue: ShortcutFieldType | WorkflowState
 }
 
 export default FlatHistory

--- a/src/teams/team.ts
+++ b/src/teams/team.ts
@@ -3,6 +3,8 @@ import axios, {AxiosError} from 'axios'
 import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
 import Member from '@sx/members/member'
 import MembersService from '@sx/members/members-service'
+import {StoryApiData} from '@sx/stories/contracts/story-api-data'
+import StoryInterface from '@sx/stories/contracts/story-interface'
 import Story from '@sx/stories/story'
 import TeamInterface from '@sx/teams/contracts/team-interface'
 import {convertApiFields} from '@sx/utils/convert-fields'
@@ -41,8 +43,8 @@ class Team extends ShortcutResource<TeamInterface> implements TeamInterface {
     if (!response) {
       throw new Error('Failed to fetch stories')
     }
-    const storiesData: Record<string, unknown>[] = response.data.data ?? []
-    return storiesData.map((story) => new Story(convertApiFields(story)))
+    const storiesData: StoryApiData[] = response.data.data ?? []
+    return storiesData.map((story) => new Story(convertApiFields<StoryApiData, StoryInterface>(story)))
   }
 
   appUrl: string

--- a/src/utils/convert-fields.ts
+++ b/src/utils/convert-fields.ts
@@ -2,19 +2,20 @@ import BaseCreateInterface from '@sx/base-create-interface'
 import BaseData from '@sx/base-data'
 import BaseInterface from '@sx/base-interface'
 import camelToSnake from '@sx/utils/camel-to-snake'
+import {ShortcutFieldType} from '@sx/utils/field-type'
 import isValidDatetimeFormat from '@sx/utils/is-valid-datetime-format'
 import snakeToCamel from '@sx/utils/snake-to-camel'
 
 
-type AnyObject = Record<string, unknown>
+type AnyObject = Record<string, ShortcutFieldType>
 
-function convertApiFields<Input extends BaseData, Resource extends BaseInterface>(object: Input): Resource {
-  const convertObject = (obj: BaseData | BaseData[]): AnyObject | Array<object> => {
+function convertApiFields<Input extends BaseData, Interface extends BaseInterface>(object: Input): Interface {
+  const convertObject = (obj: BaseData | BaseData[]): BaseData | BaseData[]=> {
     if (Array.isArray(obj)) {
-      return obj.map(item => convertObject(item)) // Recursively process each item in the array
+      return obj.map(item => <BaseData>convertObject(item)) // Recursively process each item in the array
     }
     else if (obj !== null && typeof obj === 'object') {
-      const newObj: AnyObject = {}
+      const newObj: BaseData = {}
       Object.keys(obj).forEach(key => {
         const camelKey = snakeToCamel(key)
         const value = obj[key]
@@ -23,7 +24,7 @@ function convertApiFields<Input extends BaseData, Resource extends BaseInterface
           newObj[camelKey] = new Date(value as string)
         }
         else {
-          newObj[camelKey] = typeof obj[key] === 'object' ? convertObject(obj[key] as AnyObject) : obj[key]
+          newObj[camelKey] = typeof obj[key] === 'object' ? convertObject(obj[key] as BaseData) : obj[key]
         }
       })
       return newObj
@@ -33,7 +34,7 @@ function convertApiFields<Input extends BaseData, Resource extends BaseInterface
     }
   }
 
-  return convertObject(object) as Resource
+  return convertObject(object) as Interface
 }
 
 function convertToApiFields<Input extends BaseCreateInterface, U extends BaseData>(object: Input): U {

--- a/src/utils/field-type.ts
+++ b/src/utils/field-type.ts
@@ -1,0 +1,8 @@
+import UUID from '@sx/utils/uuid'
+
+
+type ShortcutFieldType = string | number | boolean | Date | UUID | [] | object | URL | null | undefined
+
+type ShortcutApiFieldType = string | number | boolean | string[] | number[] | boolean[]  | UUID | [] | object | null
+
+export {ShortcutApiFieldType, ShortcutFieldType}

--- a/src/workflow-states/contracts/workflow-state-api-data.ts
+++ b/src/workflow-states/contracts/workflow-state-api-data.ts
@@ -2,8 +2,6 @@ import BaseData from '@sx/base-data'
 
 
 export interface WorkflowStateApiData extends BaseData {
-    [index: string]: unknown;
-
     color: string;
     createdAt: Date;
     description: string;

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,0 +1,84 @@
+import ShortcutResource from '@sx/base-resource'
+import UUID from '@sx/utils/uuid'
+
+import Bundle from '../src/bundle'
+
+// Mocks for ShortcutResource and UUID
+class Story extends ShortcutResource {
+  id: UUID | number
+  estimate?: number
+
+  constructor(data: { id: UUID | number }) {
+    super()
+    this.id = data.id
+  }
+
+  update() {
+    return Promise.resolve()
+  }
+}
+
+describe('Bundle class', () => {
+  it('should initialize with instance IDs and a factory function', () => {
+    const ids = ['123A', '123B', '123C']
+    const bundle = new Bundle<Story>(ids, data => new Story(data))
+    expect(bundle.instanceIds).toEqual(ids)
+    expect(bundle.resources.length).toBe(3)
+    expect(bundle.factory).toBeInstanceOf(Function)
+  })
+
+  it('should initialize with instances directly', () => {
+    const stories = [new Story({id: '123A'}), new Story({id: '123B'})]
+    const bundle = new Bundle<Story>(stories)
+    expect(bundle.resources).toEqual(stories)
+  })
+
+  it('should proxy property sets to all resources', async () => {
+    const stories = [new Story({id: 1}), new Story({id: 2})]
+    const bundle = new Bundle<Story>(stories)
+    bundle.estimate = 5
+    expect(bundle.estimate).toBe(5)
+    await bundle.update()
+    expect(stories[0].estimate).toBe(5)
+    expect(stories[1].estimate).toBe(5)
+  })
+
+  it('should track changes made through the proxy', () => {
+    const bundle = new Bundle<Story>(['123A'], ({id}) => new Story({id}))
+    bundle.estimate = 3
+    expect(bundle.changedFields).toContain('estimate')
+  })
+
+  it('should update all instances via the API when update is called', async () => {
+    const stories = [new Story({id: 1}), new Story({id: 2})]
+    jest.spyOn(stories[0], 'update').mockResolvedValue()
+    jest.spyOn(stories[1], 'update').mockResolvedValue()
+
+    const bundle = new Bundle<Story>(stories)
+    bundle.estimate = 3
+    await bundle.update()
+
+    expect(stories[0].update).toHaveBeenCalled()
+    expect(stories[1].update).toHaveBeenCalled()
+    expect(stories[0].estimate).toBe(3)
+    expect(stories[1].estimate).toBe(3)
+  })
+
+  it('should not update properties starting with underscore', async () => {
+    const story = new Story({id: 1})
+    story._private = 1
+
+    const bundle = new Bundle<Story>([story])
+    bundle._private = 2
+    await bundle.update()
+
+    expect(story._private).toBe(1) // unchanged
+  })
+
+  it('throws an error if trying to set a property not defined on the resource', () => {
+    const bundle = new Bundle<Story>([new Story({id: 1})])
+    expect(() => {
+      bundle.nonExistentProp = 10
+    }).toThrow()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5272,9 +5272,9 @@ typed-array-length@^1.0.6:
     possible-typed-array-names "^1.0.0"
 
 typedoc-plugin-coverage@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/typedoc-plugin-coverage/-/typedoc-plugin-coverage-3.1.0.tgz"
-  integrity sha512-fxeJRrxQR3yM/aFZU7mOuatgRCztiMCbeNiCRVZKY6VNgOcVMC1HS+ZfZnlbLLteUOdeWleSQ6yntuipz5zi6A==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-coverage/-/typedoc-plugin-coverage-3.1.1.tgz#dda6f4d12a870ffd231b24d53be859e2e44d9c31"
+  integrity sha512-PAMYQ4fX7wJo6Y8mMzrISDNRurl5+xSNWEojrt6Yxofb/m7vWrgiP3bid2KXloMlPcSfCoBiJA6F2g3rmu8XTQ==
 
 typescript@^5.4.4, typescript@^5.4.5:
   version "5.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,14 +1544,14 @@
     ts-api-utils "^1.3.0"
 
 "@typescript-eslint/parser@^7.5.0":
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-7.7.1.tgz#f940e9f291cdca40c46cb75916217d3a42d6ceea"
-  integrity sha512-vmPzBOOtz48F6JAGVS/kZYk4EkXao6iGrD838sp1w3NQQC0W8ry/q641KU4PrG7AKNAf56NOcR8GOpH8l9FPCw==
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-7.8.0.tgz#1e1db30c8ab832caffee5f37e677dbcb9357ddc8"
+  integrity sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "7.7.1"
-    "@typescript-eslint/types" "7.7.1"
-    "@typescript-eslint/typescript-estree" "7.7.1"
-    "@typescript-eslint/visitor-keys" "7.7.1"
+    "@typescript-eslint/scope-manager" "7.8.0"
+    "@typescript-eslint/types" "7.8.0"
+    "@typescript-eslint/typescript-estree" "7.8.0"
+    "@typescript-eslint/visitor-keys" "7.8.0"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@7.7.1":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,7 +1474,7 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/json-schema@^7.0.12", "@types/json-schema@^7.0.15":
+"@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -1504,7 +1504,7 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/semver@^7.5.0", "@types/semver@^7.5.8":
+"@types/semver@^7.5.8":
   version "7.5.8"
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
@@ -1554,14 +1554,6 @@
     "@typescript-eslint/visitor-keys" "7.7.1"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@6.21.0":
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz"
-  integrity sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==
-  dependencies:
-    "@typescript-eslint/types" "6.21.0"
-    "@typescript-eslint/visitor-keys" "6.21.0"
-
 "@typescript-eslint/scope-manager@7.7.1":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.7.1.tgz#07fe59686ca843f66e3e2b5c151522bc38effab2"
@@ -1569,6 +1561,14 @@
   dependencies:
     "@typescript-eslint/types" "7.7.1"
     "@typescript-eslint/visitor-keys" "7.7.1"
+
+"@typescript-eslint/scope-manager@7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.8.0.tgz#bb19096d11ec6b87fb6640d921df19b813e02047"
+  integrity sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==
+  dependencies:
+    "@typescript-eslint/types" "7.8.0"
+    "@typescript-eslint/visitor-keys" "7.8.0"
 
 "@typescript-eslint/type-utils@7.7.1":
   version "7.7.1"
@@ -1580,29 +1580,15 @@
     debug "^4.3.4"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/types@6.21.0":
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz"
-  integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
-
 "@typescript-eslint/types@7.7.1":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.7.1.tgz#f903a651fb004c75add08e4e9e207f169d4b98d7"
   integrity sha512-AmPmnGW1ZLTpWa+/2omPrPfR7BcbUU4oha5VIbSbS1a1Tv966bklvLNXxp3mrbc+P2j4MNOTfDffNsk4o0c6/w==
 
-"@typescript-eslint/typescript-estree@6.21.0":
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz"
-  integrity sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==
-  dependencies:
-    "@typescript-eslint/types" "6.21.0"
-    "@typescript-eslint/visitor-keys" "6.21.0"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    minimatch "9.0.3"
-    semver "^7.5.4"
-    ts-api-utils "^1.0.1"
+"@typescript-eslint/types@7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.8.0.tgz#1fd2577b3ad883b769546e2d1ef379f929a7091d"
+  integrity sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==
 
 "@typescript-eslint/typescript-estree@7.7.1":
   version "7.7.1"
@@ -1611,6 +1597,20 @@
   dependencies:
     "@typescript-eslint/types" "7.7.1"
     "@typescript-eslint/visitor-keys" "7.7.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "^9.0.4"
+    semver "^7.6.0"
+    ts-api-utils "^1.3.0"
+
+"@typescript-eslint/typescript-estree@7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.8.0.tgz#b028a9226860b66e623c1ee55cc2464b95d2987c"
+  integrity sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==
+  dependencies:
+    "@typescript-eslint/types" "7.8.0"
+    "@typescript-eslint/visitor-keys" "7.8.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -1631,26 +1631,18 @@
     "@typescript-eslint/typescript-estree" "7.7.1"
     semver "^7.6.0"
 
-"@typescript-eslint/utils@^6.13.0":
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz"
-  integrity sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==
+"@typescript-eslint/utils@^6.13.0 || ^7.0.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-7.8.0.tgz#57a79f9c0c0740ead2f622e444cfaeeb9fd047cd"
+  integrity sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
-    "@types/json-schema" "^7.0.12"
-    "@types/semver" "^7.5.0"
-    "@typescript-eslint/scope-manager" "6.21.0"
-    "@typescript-eslint/types" "6.21.0"
-    "@typescript-eslint/typescript-estree" "6.21.0"
-    semver "^7.5.4"
-
-"@typescript-eslint/visitor-keys@6.21.0":
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz"
-  integrity sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==
-  dependencies:
-    "@typescript-eslint/types" "6.21.0"
-    eslint-visitor-keys "^3.4.1"
+    "@types/json-schema" "^7.0.15"
+    "@types/semver" "^7.5.8"
+    "@typescript-eslint/scope-manager" "7.8.0"
+    "@typescript-eslint/types" "7.8.0"
+    "@typescript-eslint/typescript-estree" "7.8.0"
+    semver "^7.6.0"
 
 "@typescript-eslint/visitor-keys@7.7.1":
   version "7.7.1"
@@ -1658,6 +1650,14 @@
   integrity sha512-gBL3Eq25uADw1LQ9kVpf3hRM+DWzs0uZknHYK3hq4jcTPqVCClHGDnB6UUUV2SFeBeA4KWHWbbLqmbGcZ4FYbw==
   dependencies:
     "@typescript-eslint/types" "7.7.1"
+    eslint-visitor-keys "^3.4.3"
+
+"@typescript-eslint/visitor-keys@7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.8.0.tgz#7285aab991da8bee411a42edbd5db760d22fdd91"
+  integrity sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==
+  dependencies:
+    "@typescript-eslint/types" "7.8.0"
     eslint-visitor-keys "^3.4.3"
 
 "@ungap/structured-clone@^1.2.0":
@@ -2648,11 +2648,11 @@ eslint-plugin-import@^2.29.1:
     tsconfig-paths "^3.15.0"
 
 eslint-plugin-perfectionist@^2.7.0:
-  version "2.9.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.9.0.tgz"
-  integrity sha512-ipFtDrqtF99qVVo+FE1fo6aHyLLp7hg6PNGfzY5KxQjcl0XCbyEFvjtR1NfkHDTN9rdFeEDxg59LLOv3VOAHAw==
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.10.0.tgz#15cf9f5545ce2db24d1ccdf3226645a097480faf"
+  integrity sha512-P+tdrkHeMWBc55+DZsoDOAftV1WCsEoHaKm6JC7zajFus/syfT4vUPBFb3atGFSuyaVnGQGHlcKpP9X3Q0gH/w==
   dependencies:
-    "@typescript-eslint/utils" "^6.13.0"
+    "@typescript-eslint/utils" "^6.13.0 || ^7.0.0"
     minimatch "^9.0.3"
     natural-compare-lite "^1.4.0"
 
@@ -4229,13 +4229,6 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -5144,7 +5137,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-ts-api-utils@^1.0.1, ts-api-utils@^1.3.0:
+ts-api-utils@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz"
   integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,15 +1527,15 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^7.5.0":
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.7.1.tgz#50a9044e3e5fe76b22caf64fb7fc1f97614bdbfd"
-  integrity sha512-KwfdWXJBOviaBVhxO3p5TJiLpNuh2iyXyjmWN0f1nU87pwyvfS0EmjC6ukQVYVFJd/K1+0NWGPDXiyEyQorn0Q==
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.8.0.tgz#c78e309fe967cb4de05b85cdc876fb95f8e01b6f"
+  integrity sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==
   dependencies:
     "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "7.7.1"
-    "@typescript-eslint/type-utils" "7.7.1"
-    "@typescript-eslint/utils" "7.7.1"
-    "@typescript-eslint/visitor-keys" "7.7.1"
+    "@typescript-eslint/scope-manager" "7.8.0"
+    "@typescript-eslint/type-utils" "7.8.0"
+    "@typescript-eslint/utils" "7.8.0"
+    "@typescript-eslint/visitor-keys" "7.8.0"
     debug "^4.3.4"
     graphemer "^1.4.0"
     ignore "^5.3.1"
@@ -1570,13 +1570,13 @@
     "@typescript-eslint/types" "7.8.0"
     "@typescript-eslint/visitor-keys" "7.8.0"
 
-"@typescript-eslint/type-utils@7.7.1":
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-7.7.1.tgz#2f8094edca3bebdaad009008929df645ed9c8743"
-  integrity sha512-ZksJLW3WF7o75zaBPScdW1Gbkwhd/lyeXGf1kQCxJaOeITscoSl0MjynVvCzuV5boUz/3fOI06Lz8La55mu29Q==
+"@typescript-eslint/type-utils@7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-7.8.0.tgz#9de166f182a6e4d1c5da76e94880e91831e3e26f"
+  integrity sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==
   dependencies:
-    "@typescript-eslint/typescript-estree" "7.7.1"
-    "@typescript-eslint/utils" "7.7.1"
+    "@typescript-eslint/typescript-estree" "7.8.0"
+    "@typescript-eslint/utils" "7.8.0"
     debug "^4.3.4"
     ts-api-utils "^1.3.0"
 
@@ -1618,20 +1618,7 @@
     semver "^7.6.0"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/utils@7.7.1":
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-7.7.1.tgz#5d161f2b4a55e1bc38b634bebb921e4bd4e4a16e"
-  integrity sha512-QUvBxPEaBXf41ZBbaidKICgVL8Hin0p6prQDu6bbetWo39BKbWJxRsErOzMNT1rXvTll+J7ChrbmMCXM9rsvOQ==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.4.0"
-    "@types/json-schema" "^7.0.15"
-    "@types/semver" "^7.5.8"
-    "@typescript-eslint/scope-manager" "7.7.1"
-    "@typescript-eslint/types" "7.7.1"
-    "@typescript-eslint/typescript-estree" "7.7.1"
-    semver "^7.6.0"
-
-"@typescript-eslint/utils@^6.13.0 || ^7.0.0":
+"@typescript-eslint/utils@7.8.0", "@typescript-eslint/utils@^6.13.0 || ^7.0.0":
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-7.8.0.tgz#57a79f9c0c0740ead2f622e444cfaeeb9fd047cd"
   integrity sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==


### PR DESCRIPTION
## What's Changed
- Bulk operations are now supported via the `Bundle` object
- Add `SearchResponse` type for better typescript support of `BaseSearchableService.search`

_Internal_
- [Bump typedoc-plugin-coverage from 3.1.0 to 3.1.1 (](https://github.com/JensAstrup/shortcut/commit/81444333b10a3d93884c2a12710f70292866dde4)
- [Bump eslint-plugin-perfectionist from 2.9.0 to 2.10.0 (](https://github.com/JensAstrup/shortcut/commit/861d620c4206b8e90aee9748861a72fa7b23e9b7)
- [Bump @typescript-eslint/eslint-plugin from 7.7.1 to 7.8.0 (](https://github.com/JensAstrup/shortcut/commit/6953160bb8c33a5f6121fac623377e4c656d8450)
- [Bump @typescript-eslint/parser from 7.7.1 to 7.8.0 (](https://github.com/JensAstrup/shortcut/commit/b44d9b96b043f0a44a957a5402919db7896b7ec0)