### PR TITLE
4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/parser": "^7.5.0",
     "axios-mock-adapter": "^1.22.0",
     "eslint": "^8.57.0",
-    "eslint-config-yenz": "^1.0.6",
+    "eslint-config-yenz": "^2.0.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-perfectionist": "^2.7.0",
     "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-api",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/base-resource.ts
+++ b/src/base-resource.ts
@@ -17,7 +17,7 @@ export type ResourceOperation = 'update' | 'create' | 'delete' | 'comment'
  * Base class for all Shortcut resources. Provides methods for creating, updating, and deleting resources.
  * @group Story
  */
-export default abstract class ShortcutResource<Interface = BaseInterface> {
+export default abstract class BaseResource<Interface = BaseInterface> {
   [key: string]: ShortcutFieldType
 
   /**
@@ -34,7 +34,7 @@ export default abstract class ShortcutResource<Interface = BaseInterface> {
    */
   public availableOperations: ResourceOperation[] = []
 
-  public service: BaseService<ShortcutResource, BaseInterface> | BaseSearchableService<ShortcutResource, BaseInterface>
+  public service: BaseService<BaseResource, BaseInterface> | BaseSearchableService<BaseResource, BaseInterface>
   /**
    * Return a Proxy object to intercept property access and set operations on derived classes.
    * The Proxy object will track changes made to the object and store them in the `changedFields` property
@@ -47,8 +47,8 @@ export default abstract class ShortcutResource<Interface = BaseInterface> {
     }
     this.changedFields = []
     // Check to ensure that the baseUrl property is overridden in the subclass
-    if (this.constructor === ShortcutResource) {
-      (this.constructor as typeof ShortcutResource).baseUrl
+    if (this.constructor === BaseResource) {
+      (this.constructor as typeof BaseResource).baseUrl
     }
     return new Proxy(this, {
       get(target, property, receiver) {
@@ -81,7 +81,7 @@ export default abstract class ShortcutResource<Interface = BaseInterface> {
     if (!(this.availableOperations.includes('update'))) {
       throw new Error('Update operation not available for this resource')
     }
-    const baseUrl = (this.constructor as typeof ShortcutResource).baseUrl
+    const baseUrl = (this.constructor as typeof BaseResource).baseUrl
     const url = `${baseUrl}/${this.id}`
     const body = this.changedFields.reduce((acc: Record<string, unknown>, field) => {
       if (field.startsWith('_')) {
@@ -115,7 +115,7 @@ export default abstract class ShortcutResource<Interface = BaseInterface> {
     if (!(this.availableOperations.includes('create'))) {
       throw new Error('Create operation not available for this resource')
     }
-    const baseUrl = (this.constructor as typeof ShortcutResource).baseUrl
+    const baseUrl = (this.constructor as typeof BaseResource).baseUrl
     const body: Record<string, unknown> = {}
     Object.keys(this).forEach(key => {
       if (this.createFields.includes(key)) {

--- a/src/base-service.ts
+++ b/src/base-service.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 import BaseData from '@sx/base-data'
 import BaseInterface from '@sx/base-interface'
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import {convertApiFields} from '@sx/utils/convert-fields'
 import {ShortcutApiFieldType} from '@sx/utils/field-type'
 import SearchResponse from '@sx/utils/search-response'
@@ -12,7 +12,7 @@ import UUID from '@sx/utils/uuid'
 type ServiceOperation = 'get' | 'search' | 'list'
 
 
-class BaseService<Resource extends ShortcutResource, Interface extends BaseInterface> {
+class BaseService<Resource extends BaseResource, Interface extends BaseInterface> {
   public baseUrl = ''
   public headers: Record<string, string>
   protected factory: (data: Interface) => Resource
@@ -74,7 +74,7 @@ class BaseService<Resource extends ShortcutResource, Interface extends BaseInter
 }
 
 
-class BaseSearchableService<Resource extends ShortcutResource, Interface extends BaseInterface> extends BaseService<Resource, Interface> {
+class BaseSearchableService<Resource extends BaseResource, Interface extends BaseInterface> extends BaseService<Resource, Interface> {
   public availableOperations: ServiceOperation[] = ['search']
 
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,4 +1,4 @@
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import {ShortcutFieldType} from '@sx/utils/field-type'
 import UUID from '@sx/utils/uuid'
 
@@ -14,14 +14,14 @@ import UUID from '@sx/utils/uuid'
  * bundle.estimate = 3
  * bundle.update() // Changes are propagated to the instances and sent to the API
  */
-class Bundle<R extends ShortcutResource>{
+class Bundle<R extends BaseResource>{
   [key: string]: ShortcutFieldType
 
   id?: string | number | null | undefined
 
   public changedFields: string[] = []
   public instanceIds: UUID[] | number[] = []
-  public resources: ShortcutResource[]
+  public resources: BaseResource[]
   public factory: (data: { id: UUID | number }) => R
 
 

--- a/src/custom-fields/custom-field.ts
+++ b/src/custom-fields/custom-field.ts
@@ -1,10 +1,10 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import CustomFieldEnumValueInterface from '@sx/custom-fields/contracts/custom-field-enum-value-interface'
 import CustomFieldInterface from '@sx/custom-fields/contracts/custom-field-interface'
 import UUID from '@sx/utils/uuid'
 
 
-export default class CustomField extends ShortcutResource<CustomFieldInterface> implements CustomFieldInterface {
+export default class CustomField extends BaseResource<CustomFieldInterface> implements CustomFieldInterface {
   public baseUrl = 'https://api.app.shortcut.com/api/v3/custom-fields'
   public availableOperations: ResourceOperation[] = ['update', 'delete']
 

--- a/src/epics/epic.ts
+++ b/src/epics/epic.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 import BaseData from '@sx/base-data'
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import EpicInterface from '@sx/epics/contracts/epic-interface'
 import Member from '@sx/members/member'
 import MembersService from '@sx/members/members-service'
@@ -18,7 +18,7 @@ import {getHeaders} from '@sx/utils/headers'
 import UUID from '@sx/utils/uuid'
 
 
-export default class Epic extends ShortcutResource<EpicInterface> implements EpicInterface {
+export default class Epic extends BaseResource<EpicInterface> implements EpicInterface {
   public static baseUrl: string = 'https://api.app.shortcut.com/api/v3/epics'
   public createFields: string[] = ['completedAtOverride', 'createdAt', 'deadline', 'description',
     'epicStateId', 'externalId', 'followerIds', 'groupId', 'groupIds', 'labels', 'milestoneId',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
 // Resources
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import Client from '@sx/client'
 import Iteration from '@sx/iterations/iteration'
 import Member from '@sx/members/member'
@@ -92,4 +92,4 @@ export {
   UploadedFileInterface
 
 }
-export {Bundle, ShortcutResource, SearchResponse}
+export {Bundle, BaseResource, SearchResponse}

--- a/src/iterations/iteration.ts
+++ b/src/iterations/iteration.ts
@@ -1,4 +1,4 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import IterationInterface, {IterationStats, IterationStatus, Label} from '@sx/iterations/contracts/iteration-interface'
 import Team from '@sx/teams/team'
 import TeamsService from '@sx/teams/teams-service'
@@ -8,7 +8,7 @@ import {getHeaders} from '@sx/utils/headers'
 /**
  * @InheritDoc
  */
-class Iteration extends ShortcutResource<IterationInterface> implements IterationInterface {
+class Iteration extends BaseResource<IterationInterface> implements IterationInterface {
   public static baseUrl = 'https://api.app.shortcut.com/api/v3/iterations'
   public createFields: string[] = ['name', 'startDate', 'endDate', 'labels']
   public availableOperations: ResourceOperation[] = ['create', 'update', 'delete']

--- a/src/key-results/key-result.ts
+++ b/src/key-results/key-result.ts
@@ -1,10 +1,10 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import KeyResultInterface, {KeyResultType} from '@sx/key-results/contracts/key-result-interface'
 import KeyResultValueInterface from '@sx/key-results/contracts/key-result-value-interface'
 import UUID from '@sx/utils/uuid'
 
 
-export default class KeyResult extends ShortcutResource<KeyResultInterface> implements KeyResultInterface {
+export default class KeyResult extends BaseResource<KeyResultInterface> implements KeyResultInterface {
   public availableOperations: ResourceOperation[] = ['update']
 
   constructor(init: object) {

--- a/src/labels/label.ts
+++ b/src/labels/label.ts
@@ -2,7 +2,7 @@ import * as console from 'node:console'
 
 import axios, {AxiosResponse} from 'axios'
 
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import EpicApiData from '@sx/epics/contracts/epic-api-data'
 import Epic from '@sx/epics/epic'
 import LabelInterface from '@sx/labels/contracts/label-interface'
@@ -13,7 +13,7 @@ import {handleResponseFailure} from '@sx/utils/handle-response-failure'
 import {getHeaders} from '@sx/utils/headers'
 
 
-export default class Label extends ShortcutResource<LabelInterface> implements LabelInterface {
+export default class Label extends BaseResource<LabelInterface> implements LabelInterface {
   public static baseUrl: string = 'https://api.app.shortcut.com/api/v3/labels'
   public createFields = ['color', 'description', 'externalId', 'name']
   public availableOperations: ResourceOperation[] = ['create', 'update', 'delete']

--- a/src/linked-files/linked-file.ts
+++ b/src/linked-files/linked-file.ts
@@ -1,4 +1,4 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import LinkedFileInterface from '@sx/linked-files/contracts/linked-file-interface'
 import StoriesService from '@sx/stories/stories-service'
 import Story from '@sx/stories/story'
@@ -10,9 +10,9 @@ import UUID from '@sx/utils/uuid'
  * @remarks
  * Related: {@link LinkedFilesService} for the service managing stories.
  *
- * @inheritDoc ShortcutResource
+ * @inheritDoc BaseResource
  */
-export default class LinkedFile extends ShortcutResource<LinkedFileInterface> implements LinkedFileInterface {
+export default class LinkedFile extends BaseResource<LinkedFileInterface> implements LinkedFileInterface {
   public baseUrl = 'https://api.app.shortcut.com/api/v3/linked-files'
   public availableOperations: ResourceOperation[] = ['create', 'update', 'delete']
   public createFields = ['contentType', 'description', 'name', 'size', 'storyId', 'type', 'uploaderId', 'url']

--- a/src/members/member.ts
+++ b/src/members/member.ts
@@ -1,4 +1,4 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import MemberInterface, {MemberState} from '@sx/members/contracts/member-interface'
 import {MemberProfile} from '@sx/members/contracts/member-profile'
 import StoryInterface from '@sx/stories/contracts/story-interface'
@@ -10,7 +10,7 @@ import {getHeaders} from '@sx/utils/headers'
 /**
  * @inheritDoc
  */
-class Member extends ShortcutResource<MemberInterface> implements MemberInterface {
+class Member extends BaseResource<MemberInterface> implements MemberInterface {
   public static baseUrl = 'https://api.app.shortcut.com/api/v3/members'
   public availableOperations: ResourceOperation[] = []
 

--- a/src/objectives/objective.ts
+++ b/src/objectives/objective.ts
@@ -1,9 +1,9 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import ObjectiveInterface from '@sx/objectives/contracts/objective-interface'
 import UUID from '@sx/utils/uuid'
 
 
-export default class Objective extends ShortcutResource<ObjectiveInterface> implements ObjectiveInterface {
+export default class Objective extends BaseResource<ObjectiveInterface> implements ObjectiveInterface {
   public baseUrl: string = 'https://api.app.shortcut.com/api/v3/objectives'
   public availableOperations: ResourceOperation[] = ['create', 'update', 'delete']
 

--- a/src/repositories/repository.ts
+++ b/src/repositories/repository.ts
@@ -1,9 +1,9 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import RepositoryInterface from '@sx/repositories/contracts/repository'
 import {RepositoryType} from '@sx/repositories/contracts/repository-api-data'
 
 
-class Repository extends ShortcutResource<RepositoryInterface> implements RepositoryInterface {
+class Repository extends BaseResource<RepositoryInterface> implements RepositoryInterface {
   public availableOperations: ResourceOperation[] = []
 
   createdAt: Date | null

--- a/src/stories/comment/story-comment.ts
+++ b/src/stories/comment/story-comment.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import StoryCommentApiData from '@sx/stories/comment/contracts/story-comment-api-data'
 import {StoryCommentInterface} from '@sx/stories/comment/contracts/story-comment-interface'
 import Story from '@sx/stories/story'
@@ -10,7 +10,7 @@ import {getHeaders} from '@sx/utils/headers'
 import UUID from '@sx/utils/uuid'
 
 
-export default class StoryComment extends ShortcutResource<StoryCommentInterface> implements StoryCommentInterface {
+export default class StoryComment extends BaseResource<StoryCommentInterface> implements StoryCommentInterface {
   public availableOperations: ResourceOperation[] = ['create', 'update', 'delete', 'comment']
 
   constructor(init: object) {

--- a/src/stories/custom-fields/story-custom-field.ts
+++ b/src/stories/custom-fields/story-custom-field.ts
@@ -17,6 +17,11 @@ export default class StoryCustomField extends ShortcutResource<StoryInterface> i
     this.changedFields = []
   }
 
+  /**
+   * Get an instance of the custom field that this story custom field is associated with. Due to the way the API works, this is a separate request.
+   * For example, `storyCustomField` has a `fieldId` of `1234`, and a value of `someValue`, but it is not possible to see the name of the field
+   * without making a separate request.
+   */
   get field(): Promise<CustomField> {
     const service = new CustomFieldsService({headers: getHeaders()})
     return service.get(this.fieldId)

--- a/src/stories/custom-fields/story-custom-field.ts
+++ b/src/stories/custom-fields/story-custom-field.ts
@@ -1,4 +1,4 @@
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import CustomField from '@sx/custom-fields/custom-field'
 import CustomFieldsService from '@sx/custom-fields/custom-fields-service'
 import StoryInterface from '@sx/stories/contracts/story-interface'
@@ -7,7 +7,7 @@ import {getHeaders} from '@sx/utils/headers'
 import UUID from '@sx/utils/uuid'
 
 
-export default class StoryCustomField extends ShortcutResource<StoryInterface> implements StoryCustomFieldInterface {
+export default class StoryCustomField extends BaseResource<StoryInterface> implements StoryCustomFieldInterface {
   public baseUrl = 'https://api.app.shortcut.com/api/v3/stories'
   public availableOperations = []
 

--- a/src/stories/history/actions/history-action.ts
+++ b/src/stories/history/actions/history-action.ts
@@ -1,4 +1,4 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import Label from '@sx/labels/label'
 import LabelsService from '@sx/labels/labels-service'
 import Member from '@sx/members/member'
@@ -8,7 +8,7 @@ import {getHeaders} from '@sx/utils/headers'
 import UUID from '@sx/utils/uuid'
 
 
-class HistoryAction extends ShortcutResource<HistoryActionInterface> implements HistoryActionInterface {
+class HistoryAction extends BaseResource<HistoryActionInterface> implements HistoryActionInterface {
   public availableOperations: ResourceOperation[] = []
 
   constructor(init: HistoryActionInterface) {

--- a/src/stories/history/history.ts
+++ b/src/stories/history/history.ts
@@ -1,7 +1,7 @@
 import ShortcutResource from '@sx/base-resource'
 import Member from '@sx/members/member'
 import MembersService from '@sx/members/members-service'
-import HistoryActionInterface, {HistoryActionChangeInterface} from '@sx/stories/history/actions/contracts/history-action-interface'
+import {HistoryActionChangeInterface} from '@sx/stories/history/actions/contracts/history-action-interface'
 import HistoryAction from '@sx/stories/history/actions/history-action'
 import HistoryInterface from '@sx/stories/history/contracts/history-interface'
 import FlatHistory from '@sx/stories/history/flat-history'
@@ -55,7 +55,7 @@ class History extends ShortcutResource<HistoryInterface> implements HistoryInter
   }
 
 
-  actions: HistoryActionInterface[] | HistoryAction[]
+  actions: HistoryAction[]
   changedAt: Date
   externalId: string
   id: UUID

--- a/src/stories/history/history.ts
+++ b/src/stories/history/history.ts
@@ -1,4 +1,4 @@
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import Member from '@sx/members/member'
 import MembersService from '@sx/members/members-service'
 import {HistoryActionChangeInterface} from '@sx/stories/history/actions/contracts/history-action-interface'
@@ -10,7 +10,7 @@ import {getHeaders} from '@sx/utils/headers'
 import UUID from '@sx/utils/uuid'
 
 
-class History extends ShortcutResource<HistoryInterface> implements HistoryInterface {
+class History extends BaseResource<HistoryInterface> implements HistoryInterface {
   constructor(init: HistoryInterface) {
     super()
     Object.assign(this, init)

--- a/src/stories/links/story-link.ts
+++ b/src/stories/links/story-link.ts
@@ -1,8 +1,8 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import StoryLinkInterface from '@sx/stories/links/contracts/story-link-interface'
 
 
-export default class StoryLink extends ShortcutResource<StoryLinkInterface> implements StoryLinkInterface {
+export default class StoryLink extends BaseResource<StoryLinkInterface> implements StoryLinkInterface {
   public static baseUrl = 'https://api.app.shortcut.com/api/v3/story-links'
   public availableOperations: ResourceOperation[] = ['delete', 'create', 'update']
   public createFields: string[] = ['subjectId', 'verb', 'objectId']

--- a/src/stories/story.ts
+++ b/src/stories/story.ts
@@ -303,13 +303,13 @@ class Story extends ShortcutResource<StoryInterface> implements StoryInterface {
   blocked: boolean
   blocker: boolean
   branches: object[]
-  comments: StoryCommentInterface[] | StoryComment[]
+  comments: StoryComment[]
   commits: object[]
   completed: boolean
   completedAt: Date | null
   completedAtOverride: Date | null
   createdAt: Date
-  customFields: StoryCustomFieldInterface[] | StoryCustomField[]
+  customFields: StoryCustomField[]
   deadline: Date | null
   description: string
   entityType: string
@@ -340,11 +340,11 @@ class Story extends ShortcutResource<StoryInterface> implements StoryInterface {
   startedAt: Date | null
   startedAtOverride: Date | null
   stats: object
-  storyLinks: StoryLinkInterface[] | StoryLink[]
+  storyLinks: StoryLink[]
   storyTemplateId: string | null
   storyType: string
   syncedItem: object
-  tasks: Task[] | TaskInterface[]
+  tasks: Task[]
   unresolvedBlockerComments: number[]
   updatedAt: Date | null
   workflowId: number

--- a/src/stories/story.ts
+++ b/src/stories/story.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import Epic from '@sx/epics/epic'
 import EpicsService from '@sx/epics/epics-service'
 import Iteration from '@sx/iterations/iteration'
@@ -40,9 +40,9 @@ import WorkflowService from '@sx/workflows/workflows-service'
  * Related: {@link StoriesService} for the service managing stories.
  *
  * @story
- * @inheritDoc ShortcutResource
+ * @inheritDoc BaseResource
  */
-class Story extends ShortcutResource<StoryInterface> implements StoryInterface {
+class Story extends BaseResource<StoryInterface> implements StoryInterface {
   public static baseUrl: string = 'https://api.app.shortcut.com/api/v3/stories'
   public availableOperations: ResourceOperation[] = ['create', 'update', 'delete', 'comment']
 

--- a/src/stories/tasks/task.ts
+++ b/src/stories/tasks/task.ts
@@ -1,8 +1,8 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import UUID from '@sx/utils/uuid'
 
 
-export default class Task extends ShortcutResource {
+export default class Task extends BaseResource {
   public baseUrl = 'https://api.app.shortcut.com/api/v3/stories/'
   public availableOperations: ResourceOperation[] = ['update', 'delete']
   public createFields = ['complete', 'createdAt', 'description', 'externalId', 'ownerIds', 'updatedAt']

--- a/src/teams/team.ts
+++ b/src/teams/team.ts
@@ -1,6 +1,6 @@
 import axios, {AxiosError} from 'axios'
 
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import Member from '@sx/members/member'
 import MembersService from '@sx/members/members-service'
 import {StoryApiData} from '@sx/stories/contracts/story-api-data'
@@ -15,7 +15,7 @@ import {getHeaders} from '@sx/utils/headers'
 /**
  * @inheritDoc
  */
-class Team extends ShortcutResource<TeamInterface> implements TeamInterface {
+class Team extends BaseResource<TeamInterface> implements TeamInterface {
   public static baseUrl = 'https://api.app.shortcut.com/api/v3/groups' // Shortcut renamed groups to teams
   public createFields: string[] = ['name', 'mentionName']
   public availableOperations: ResourceOperation[] = ['create', 'update', 'delete']

--- a/src/uploaded-files/uploaded-file.ts
+++ b/src/uploaded-files/uploaded-file.ts
@@ -1,9 +1,9 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import UploadedFileInterface from '@sx/uploaded-files/contracts/uploaded-file-interface'
 import UUID from '@sx/utils/uuid'
 
 
-export default class UploadedFile extends ShortcutResource<UploadedFileInterface> implements UploadedFileInterface {
+export default class UploadedFile extends BaseResource<UploadedFileInterface> implements UploadedFileInterface {
   public baseUrl = 'https://api.app.shortcut.com/api/v3/files'
   public availableOperations: ResourceOperation[] = ['update', 'delete']
 

--- a/src/utils/convert-to-resource.ts
+++ b/src/utils/convert-to-resource.ts
@@ -1,5 +1,5 @@
 import BaseInterface from '@sx/base-interface'
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import BaseService from '@sx/base-service'
 import MembersService from '@sx/members/members-service'
 import {getHeaders} from '@sx/utils/headers'
@@ -11,7 +11,7 @@ interface ResourceMap {
   // Define a map of keys to resources, where the key is the field name in the data, and the value is a constructor for the resource and service
   [key: string]: {
     operation: 'get' | 'getMany'
-    service: typeof BaseService<ShortcutResource, BaseInterface>,
+    service: typeof BaseService<BaseResource, BaseInterface>,
   }
 }
 
@@ -23,7 +23,7 @@ class ResourceConverter {
   }
 
 
-  async getResourceFromId(resourceId: UUID | UUID[] | number | number[], key: string | number): Promise<ShortcutResource | Array<ShortcutResource | null> | null> {
+  async getResourceFromId(resourceId: UUID | UUID[] | number | number[], key: string | number): Promise<BaseResource | Array<BaseResource | null> | null> {
     if (!this.resourceMap[key]) return null
     const service = new this.resourceMap[key].service({headers: getHeaders()})
     if (this.resourceMap[key].operation === 'get') {

--- a/src/utils/search-response.ts
+++ b/src/utils/search-response.ts
@@ -1,9 +1,9 @@
 import BaseInterface from '@sx/base-interface'
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import {BaseSearchableService} from '@sx/base-service'
 
 
-class SearchResponse<Resource extends ShortcutResource, Interface extends BaseInterface> {
+class SearchResponse<Resource extends BaseResource, Interface extends BaseInterface> {
   public query: string
   public nextPage: undefined | string | null
   public results: Resource[]

--- a/src/workflow-states/workflow-state.ts
+++ b/src/workflow-states/workflow-state.ts
@@ -1,8 +1,8 @@
-import ShortcutResource, {ResourceOperation} from '@sx/base-resource'
+import BaseResource, {ResourceOperation} from '@sx/base-resource'
 import WorkflowStateInterface, {WorkflowStateType} from '@sx/workflow-states/contracts/workflow-state-interface'
 
 
-class WorkflowState extends ShortcutResource<WorkflowStateInterface> implements WorkflowStateInterface {
+class WorkflowState extends BaseResource<WorkflowStateInterface> implements WorkflowStateInterface {
   public availableOperations: ResourceOperation[] = []
 
   constructor(init: WorkflowStateInterface) {

--- a/src/workflows/workflow.ts
+++ b/src/workflows/workflow.ts
@@ -1,4 +1,4 @@
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import WorkflowStateInterface from '@sx/workflow-states/contracts/workflow-state-interface'
 import WorkflowInterface from '@sx/workflows/contracts/workflow-interface'
 
@@ -6,7 +6,7 @@ import WorkflowInterface from '@sx/workflows/contracts/workflow-interface'
 /**
  * @inheritDoc
  */
-export default class Workflow extends ShortcutResource<WorkflowInterface> implements WorkflowInterface {
+export default class Workflow extends BaseResource<WorkflowInterface> implements WorkflowInterface {
   constructor(init: object) {
     super()
     Object.assign(this, init)

--- a/tests/base-resource.test.ts
+++ b/tests/base-resource.test.ts
@@ -12,7 +12,7 @@ import mocked = jest.mocked
 
 const mockedAxios = mocked(axios)
 
-describe('ShortcutResource', () => {
+describe('BaseResource', () => {
   const mockHeaders = {
     'Content-Type': 'application/json',
     'Shortcut-Token': 'token'

--- a/tests/base-service.test.ts
+++ b/tests/base-service.test.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 import BaseInterface from '../src/base-interface'
-import ShortcutResource from '../src/base-resource'
+import BaseResource from '../src/base-resource'
 import {BaseSearchableService, BaseService, ServiceOperation} from '../src/base-service'
 
 import mocked = jest.mocked
@@ -15,7 +15,7 @@ interface MockInterface extends BaseInterface {
   name: string
 }
 
-class MockResource extends ShortcutResource implements MockInterface {
+class MockResource extends BaseResource implements MockInterface {
   constructor(data: MockInterface) {
     super(data)
     Object.assign(this, data)

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,10 +1,10 @@
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import UUID from '@sx/utils/uuid'
 
 import Bundle from '../src/bundle'
 
-// Mocks for ShortcutResource and UUID
-class Story extends ShortcutResource {
+// Mocks for BaseResource and UUID
+class Story extends BaseResource {
   id: UUID | number
   estimate?: number
 

--- a/tests/utils/search-response.test.ts
+++ b/tests/utils/search-response.test.ts
@@ -1,11 +1,11 @@
 import BaseInterface from '@sx/base-interface'
-import ShortcutResource from '@sx/base-resource'
+import BaseResource from '@sx/base-resource'
 import {BaseSearchableService} from '@sx/base-service'
 import {SearchResponse} from '@sx/index'
 
 
-// Mock for ShortcutResource
-class MockResource extends ShortcutResource {
+// Mock for BaseResource
+class MockResource extends BaseResource {
   id: string
 
   constructor(id: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2631,10 +2631,10 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-yenz@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/eslint-config-yenz/-/eslint-config-yenz-1.0.6.tgz#1030afaeb3bfb41c386120d01e209d93e9b5a756"
-  integrity sha512-Um5CEwJtVmKLKxtml8DkaKhxhvrBc6n8Bt21QAY0Z9tYyM0g40gHdDBdTznqsohhBKOdqL/WrVueGRLNYQUqFw==
+eslint-config-yenz@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-yenz/-/eslint-config-yenz-2.0.1.tgz#e296254e99ce96363635b88411ac4ce8a8e7bfa6"
+  integrity sha512-F6z3mWPOMW34qGUEhPuyMW5z8pLbQhj7S1RUn986NvuTeMwcleJKg8VY1Ao/N8KYn7eM1uA7deYNykD/0Q3+JA==
 
 eslint-import-resolver-node@^0.3.9:
   version "0.3.9"


### PR DESCRIPTION
## What's Changed
- Removed type hinting that suggested fields on `Story` and `History` could be interfaces which was not possible unless writing code within the `constructor` methods of those classes. If you were explicitly stating return types  for `Story.comments`, `Story.customFields`, `Story.storyLinks`, `Story.tasks`, or `History.actions` you should remove the interface portion of those type annotations. 
- Renamed `ShortcutResource` to `BaseResource` - primarily an internal class, if you were using this please refactor

_Internal_
- Update eslint configuration version